### PR TITLE
Synchronize tabs in documentation by adding Starlight's `syncKey` to all `<Tabs>`

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -25,7 +25,7 @@ Every commit to select files is used to build a localization dashboard, giving e
 
 You can add Lunaria in your existing project by installing `@lunariajs/core` in your project's dependencies using your preferred package manager:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -51,7 +51,7 @@ yarn add @lunariajs/core
 
 Then, you can run `lunaria init` to setup Lunaria, prompting you with a few questions and automatically filling your answers in a new `lunaria.config.json` file:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -83,7 +83,7 @@ In case any of the fields `repository`, `defaultLocale`, `locales`, or `files` i
 
 To build your localization dashboard, you can run the `lunaria:build` script added by `lunaria init`:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh
@@ -113,7 +113,7 @@ By default, the localization dashboard will be built to an `index.html` file in 
 
 After building your dashboard, you should be able to run `lunaria:preview` to open a new preview server on [http://localhost:3000/](http://localhost:3000/).
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh

--- a/docs/src/content/docs/integrations/github-action.mdx
+++ b/docs/src/content/docs/integrations/github-action.mdx
@@ -16,7 +16,7 @@ The Lunaria GitHub Action comments on pull requests with an overview of how the 
 
 Create a new file in your project at `.github/workflows/lunaria.yml` with the following content, according to the package manager used:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```yml

--- a/docs/src/content/docs/integrations/starlight.mdx
+++ b/docs/src/content/docs/integrations/starlight.mdx
@@ -15,7 +15,7 @@ The `@lunariajs/starlight` package integrates Lunaria into the [Starlight docume
 
 2. Add the `@lunariajs/starlight` to your project with your preferred package manager:
 
-    <Tabs>
+    <Tabs syncKey="pkg">
     <TabItem label="npm">
 
     ```sh

--- a/docs/src/content/docs/manual-installation.mdx
+++ b/docs/src/content/docs/manual-installation.mdx
@@ -15,7 +15,7 @@ Follow the [Getting Started guide's "Quick Start" section](/getting-started/#qui
 
 Lunaria is published through the `@lunariajs/core` package in the npm registry. Add it to your project by running the following command in the project's root directory:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -11,7 +11,7 @@ Use the CLI by running one of the commands listed below, optionally including an
 
 You can check all the available commands and global options by typing `lunaria --help` in your terminal:
 
-<Tabs>
+<Tabs syncKey="pkg">
 <TabItem label="npm">
 
 ```sh


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- add `syncKey` to all `<Tabs>` elements
- these files got changes:
  - `getting-started.mdx`
  - `integrations/github-action.mdx`
  - `integrations/starlight.mdx`
  - `manual-installation.mdx`
  - `reference/cli.mdx`

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: `docs`
