### PR TITLE
refactor(core): modify getStringFromFormat for immutable

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -12,11 +12,10 @@ export function getStringFromFormat(
 		[part: string]: string;
 	}
 ) {
-	let formatResult = format;
-	Object.keys(placeholders).forEach((key) => {
-		formatResult = formatResult.replace(key, placeholders[key] ?? '');
-	});
-	return formatResult;
+	return Object.keys(placeholders).reduce((acc, key) => {
+		const value = placeholders[key] ?? '';
+		return acc.replace(key, value);
+	}, format);
 }
 
 export function loadWithJiti(path: string) {


### PR DESCRIPTION
## Description

This pull request refactors the `getStringFromFormat` function in `packages/core/src/utils.ts` to improve its readability and performance by replacing the `forEach` loop with a `reduce` function.

Codebase improvement:

* [`packages/core/src/utils.ts`](diffhunk://#diff-6552eacdc0f4378c00e24a96877df8352eeb0db006852dfdcf511f59d9b781aeL15-R18): Refactored the `getStringFromFormat` function to use `reduce` instead of `forEach`, streamlining the code and potentially improving performance by reducing intermediate variable assignments.